### PR TITLE
Drop support for 6.x and 11.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,5 @@
 language: node_js
 node_js:
-  - "6"
   - "8"
   - "10"
-  - "11"
   - "12"


### PR DESCRIPTION
- 6.x end of life = 2019-04-30
- 11.x end of life = 2019-06-01

https://github.com/nodejs/Release


